### PR TITLE
Improve size calculation for multiline text

### DIFF
--- a/Sources/Code/Extensions/StringExtension.swift
+++ b/Sources/Code/Extensions/StringExtension.swift
@@ -17,7 +17,7 @@ extension String {
     /// - Returns: The height needed to fit the text into a width-constrained rect.
     public func height(forFixedWidth fixedWidth: CGFloat, font: UIFont) -> CGFloat {
         let constraintSize = CGSize(width: fixedWidth, height: .greatestFiniteMagnitude)
-        return rect(for: constraintSize, font: font).height
+        return ceil(rect(for: constraintSize, font: font).height)
     }
 
     /// Calculates and returns the width needed to fit the text into a height-constrained rect.
@@ -28,7 +28,7 @@ extension String {
     /// - Returns: The width needed to fit the text into a height-constrained rect.
     public func width(forFixedHeight fixedHeight: CGFloat, font: UIFont) -> CGFloat {
         let constraintSize = CGSize(width: .greatestFiniteMagnitude, height: fixedHeight)
-        return rect(for: constraintSize, font: font).width
+        return ceil(rect(for: constraintSize, font: font).width)
     }
 
     private func rect(for constraintSize: CGSize, font: UIFont) -> CGRect {


### PR DESCRIPTION
There is an issue with UIKit elements like UILabel or UITextView not rendering the last line, 
when they are exactly constrained to the height of `-height(forFixedWidth:, font:)`.

By ceiling the value the height and width becomes the minimum height the UI elements require.