### PR TITLE
Consider the image's scale when converting to grayscale

### DIFF
--- a/Framework/Sources/Extensions/UIImageExtension.swift
+++ b/Framework/Sources/Extensions/UIImageExtension.swift
@@ -13,13 +13,13 @@ extension UIImage {
     ///
     /// - Returns: The grayscale image.
     public func toGrayscale() -> UIImage? {
-        let imageRect = CGRect(size: size)
+        let imageRect = CGRect(x: 0, y: 0, width: size.width * scale, height: size.height * scale)
         let colorSpace = CGColorSpaceCreateDeviceGray()
         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.none.rawValue)
         let contextOptional = CGContext(
             data: nil,
-            width: Int(size.width),
-            height: Int(size.height),
+            width: Int(size.width * scale),
+            height: Int(size.height * scale),
             bitsPerComponent: 8,
             bytesPerRow: 0,
             space: colorSpace,


### PR DESCRIPTION
Fixes an issue in UIImageExtension's `toGrayscale()` method. The conversion did not consider the image's `scale`. On some devices, like the iPhone 6s Plus or iPad Pro, images that were converted to grayscale using this method turned out blurry.

The fix considers the image's scale when calculating target width and height.