### PR TITLE
Revert dequeueCell interface to return Cell (instead of Cell?)

### DIFF
--- a/Frameworks/HandyUIKit/Extensions/UITableViewExt.swift
+++ b/Frameworks/HandyUIKit/Extensions/UITableViewExt.swift
@@ -4,8 +4,9 @@ import UIKit
 
 extension UITableView {
     /// Returns a reusable table view cell of type `cellType` with the name of its type as reuse identifier and adds it to the table.
-    public func dequeueCell<Cell: UITableViewCell>(ofType cellType: Cell.Type, for indexPath: IndexPath) -> Cell? {
-        dequeueReusableCell(withIdentifier: String(describing: cellType), for: indexPath) as? Cell
+    public func dequeueCell<Cell: UITableViewCell>(ofType cellType: Cell.Type, for indexPath: IndexPath) -> Cell {
+        // swiftlint:disable:next force_cast
+        dequeueReusableCell(withIdentifier: String(describing: cellType), for: indexPath) as! Cell
     }
 
     /// Returns a reusable header or footer view of type `viewType` with the name of its type as reuse identifier and adds it to the table.


### PR DESCRIPTION
This reverts the interface of the `dequeueCell` method as discussed [here](https://github.com/Flinesoft/HandyUIKit/commit/3353856a1d50df5ffd370ded078c1a21ffb18a68#r40166532).

After this is merged, it should be published in a new release as soon as possible.